### PR TITLE
fix Redis 메시지의 바이트 인코딩 변환 로직 수정

### DIFF
--- a/src/main/kotlin/com/example/community_4am_kotlin/feature/chat/common/ChatHandlerImpl.kt
+++ b/src/main/kotlin/com/example/community_4am_kotlin/feature/chat/common/ChatHandlerImpl.kt
@@ -3,6 +3,7 @@ package com.example.community_4am_kotlin.feature.chat.common
 import com.example.community_4am_kotlin.feature.chat.repository.MessageRepository
 import com.example.community_4am_kotlin.feature.chat.service.ChatService
 import com.example.community_4am_kotlin.feature.chat.service.MessageBrokerService
+import com.example.community_4am_kotlin.log
 import com.nimbusds.jose.shaded.gson.Gson
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.CloseStatus
@@ -31,7 +32,7 @@ class ChatHandlerImpl(
 
                 // WebSocketSession에서 사용자 정보 가져오기
                 val sender = wsSession.principal?.name ?: "unknown"
-
+                log.info("sender", sender)
                 // 메시지에 sender 정보 추가
                 messageData["sender"] = sender
 

--- a/src/main/kotlin/com/example/community_4am_kotlin/feature/chat/service/ChatServiceImpl.kt
+++ b/src/main/kotlin/com/example/community_4am_kotlin/feature/chat/service/ChatServiceImpl.kt
@@ -2,6 +2,7 @@ package com.example.community_4am_kotlin.feature.chat.service
 
 
 import com.example.community_4am_kotlin.feature.user.service.UserService
+import com.example.community_4am_kotlin.log
 import com.nimbusds.jose.shaded.gson.Gson
 import org.springframework.stereotype.Service
 import org.springframework.web.socket.TextMessage
@@ -29,6 +30,7 @@ class ChatServiceImpl(
         val user = userService.findByEmail(accountId)
         val nickname = user.nickname
         val sessionId = session.id
+        log.info("nickname : $nickname")
 
         // 세션 정보 저장
         roomSessions.computeIfAbsent(roomId) { ConcurrentHashMap() }[sessionId] = session

--- a/src/main/kotlin/com/example/community_4am_kotlin/feature/chat/service/RedisSubscriber.kt
+++ b/src/main/kotlin/com/example/community_4am_kotlin/feature/chat/service/RedisSubscriber.kt
@@ -22,9 +22,11 @@ class RedisSubscriber(
 ) : MessageListener {
 
     override fun onMessage(message: Message, pattern: ByteArray?) {
-        val channel = pattern?.toString() ?: return
-        val content = message.body.toString()
+        val channel = pattern?.let { String(it, Charsets.UTF_8) } ?: return
+        val content = String(message.body, Charsets.UTF_8) // 메시지 본문을 UTF-8로 변환
 
+
+        log.info("channel: $channel, content: $content")
         roomSessions[channel]?.values?.forEach { session ->
             try {
                 session.sendMessage(TextMessage(content))


### PR DESCRIPTION
문제의 원인 
val channel = pattern?.toString() ?: return
val content = message.body.toString()

:ByteArray 객체를 toString()으로 출력했기 때문에 발생하는 현상
, toString()을 호출하는 방식은 문자열을 인코딩 없이 출력하는 결과를 초래
channel: [B@1567f252, content: [B@11586426

Charsets.UTF_8 로 인코딩 후 화면에서 내용이 보이는 것을 확인 